### PR TITLE
Bugfix for getThemedLink

### DIFF
--- a/src/MarkovPHP/WordChain.php
+++ b/src/MarkovPHP/WordChain.php
@@ -59,7 +59,7 @@ class WordChain
      */
     public function getThemedLink($string)
     {
-        $search = preg_grep('/\b' . preg_quote($string, '/') . '\b/', $this->words);
+        $search = array_values(preg_grep('/\b' . preg_quote($string, '/') . '\b/', $this->words));
         return $search[array_rand($search)];
     }
 


### PR DESCRIPTION
Fixed bug where getThemedLink would almost always fail to return a usable value due to preg_grep retaining keys from the input array.